### PR TITLE
Insert spaces instead of tabs when pressing the tab key.

### DIFF
--- a/src/main/java/tddtrainer/compiler/AutoCompiler.java
+++ b/src/main/java/tddtrainer/compiler/AutoCompiler.java
@@ -53,9 +53,8 @@ public class AutoCompiler {
     }
 
     public synchronized AutoCompilerResult recompile() {
-        CompilationUnit codeCU = new CompilationUnit(exercise.getCode().getName(), code.replaceAll("\t", "    "),
-                false);
-        CompilationUnit testCU = new CompilationUnit(exercise.getTest().getName(), test.replaceAll("\t", "    "), true);
+        CompilationUnit codeCU = new CompilationUnit(exercise.getCode().getName(), code, false);
+        CompilationUnit testCU = new CompilationUnit(exercise.getTest().getName(), test, true);
         JavaStringCompiler compiler = CompilerFactory.getCompiler(codeCU, testCU);
         compiler.compileAndRunTests();
         AutoCompilerResult result = new AutoCompilerResult(compiler, exercise);

--- a/src/main/resources/editor.html
+++ b/src/main/resources/editor.html
@@ -28,9 +28,18 @@
                       { lineNumbers: true,
                         indentUnit: 4,
                         autoCloseBrackets: true,
-                        matchBrackets: true, 
-                        mode: "text/x-java" });
-                        
+                        matchBrackets: true,
+                        mode: "text/x-java",
+                        extraKeys: {
+                          Tab: function(cm) {
+                            if(cm.somethingSelected())
+                              cm.indentSelection("add");
+                            else
+                              cm.execCommand("insertSoftTab");
+                            },
+                          "Shift-Tab": function(cm) {
+                            cm.indentSelection("subtract");
+                          }}});
     editor.on("change", onChange)                 
 
     function changeFontSize(size){


### PR DESCRIPTION
0fd1dab replaced tabs with four spaces on compilation but the tabs remaind in the code.
This commit uses https://github.com/codemirror/CodeMirror/issues/988#issuecomment-40874237 to insert four spaces by pressing tab and preserves the features to indent a code block and to un-indent.