### PR TITLE
Fix issue #4

### DIFF
--- a/src/main/java/tddtrainer/compiler/AutoCompilerResult.java
+++ b/src/main/java/tddtrainer/compiler/AutoCompilerResult.java
@@ -1,6 +1,7 @@
 package tddtrainer.compiler;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -118,7 +119,12 @@ public class AutoCompilerResult {
                 sb.append(", Method: ");
                 sb.append(failure.getMethodName());
                 sb.append("\n");
-                sb.append(failure.getMessage());
+                String[] linesOfStackTrace = failure.getExceptionStackTrace().split("\n");
+                String limitedStackTrace = Arrays.stream(linesOfStackTrace).limit(8)
+                        .collect(Collectors.joining("\n")) + "\n";
+                sb.append(limitedStackTrace);
+                if (linesOfStackTrace.length > 8)
+                    sb.append("\t...\n");
                 sb.append("\n");
             }
         }


### PR DESCRIPTION
I replace the message of a failure by its stack trace in the compiler output to fix issue #4. The stack trace contains the name of thrown exception and also the message.

The actual stack trace is limited to the top seven frames avoiding a too large and meaningless output.